### PR TITLE
Optimize marshalling

### DIFF
--- a/bin/cli/src/main.cpp
+++ b/bin/cli/src/main.cpp
@@ -269,7 +269,7 @@ struct marshaling_policy {
     static void serialize_initial_phase_voter_data(const std::array<bool, encrypted_input_policy::hash_type::digest_bits> &voter_pubkey,
                                                    const std::array<bool, encrypted_input_policy::hash_type::digest_bits> &voter_skey,
                                                    std::vector<std::uint8_t> &voter_pk_out,
-                                                   std::vector<std::uint8_t> &voter_sk_out) {                                                                        endianness>));
+                                                   std::vector<std::uint8_t> &voter_sk_out) {
         voter_pk_out = serialize_bitarray<encrypted_input_policy::hash_type::digest_bits>(voter_pubkey);
         voter_sk_out = serialize_bitarray<encrypted_input_policy::hash_type::digest_bits>(voter_skey);
     }

--- a/share/wasm/wrapper.js
+++ b/share/wasm/wrapper.js
@@ -205,7 +205,7 @@ exports.generate_vote = function (tree_depth, voter_index, vote, public_keys,
     ct_buffer_out = cli._malloc(8);
     sn_buffer_out = cli._malloc(8);
 
-    cli._generate_vote(tree_depth, voter_index, vote, public_keys_super_buffer,
+    cli._generate_vote(tree_depth, eid_len, voter_index, vote, public_keys_super_buffer,
         rt_buffer, eid_buffer, sk_buffer, pk_eid_buffer,
         r1cs_proving_key_buffer, r1cs_verification_key_buffer,
         proof_buffer_out, pinput_buffer_out, ct_buffer_out,


### PR DESCRIPTION
rt, eid and sn are now packed in the primary input.
The primary input now is 30 variables, ~ 960B.
rt and eid, are now together 3 variables, ~ 96 B.
 
packing the message itself turns out to be to much of a hassle, if even possible (since it's encrypted).
So unless it is required to have an even smaller primary input, I think is solves #6