### PR TITLE
Use pregenerated merkle tree in vote phase

### DIFF
--- a/bin/cli/src/main.cpp
+++ b/bin/cli/src/main.cpp
@@ -662,7 +662,7 @@ struct marshaling_policy {
         }
         BOOST_ASSERT(hashes.size() == tree_length);
 
-        return containers::merkle_tree<encrypted_input_policy::merkle_hash_type, encrypted_input_policy::arity>(hashes.begin(), hashes.end());
+        return containers::merkle_tree<encrypted_input_policy::merkle_hash_type, encrypted_input_policy::arity>(1 << tree_depth, hashes.begin(), hashes.end());
     } 
 
     static std::vector<std::array<bool, encrypted_input_policy::public_key_bits>> read_voters_public_keys(std::size_t tree_depth,

--- a/bin/cli/src/main.cpp
+++ b/bin/cli/src/main.cpp
@@ -844,15 +844,15 @@ void process_encrypted_input_mode(const boost::program_options::variables_map &v
     std::cout << "Voters key pairs generated." << std::endl;
 
     std::cout << "Merkle tree generation upon participants public keys started..." << std::endl;
-    containers::merkle_tree<encrypted_input_policy::merkle_hash_type, encrypted_input_policy::arity> tree(
+    auto tree = containers::make_merkle_tree<encrypted_input_policy::merkle_hash_type, encrypted_input_policy::arity>(
         std::cbegin(public_keys), std::cend(public_keys));
     std::vector<scalar_field_value_type> rt_field = marshaling_policy::get_multi_field_element_from_bits(tree.root());
 
     auto public_keys_read = marshaling_policy::read_voters_public_keys(
         vm["tree-depth"].as<std::size_t>(),
         vm.count("voter-public-key-output") ? vm["voter-public-key-output"].as<std::string>() : "");
-    containers::merkle_tree<encrypted_input_policy::merkle_hash_type, encrypted_input_policy::arity>
-        tree_built_from_read(std::cbegin(public_keys_read), std::cend(public_keys_read));
+    auto tree_built_from_read = containers::make_merkle_tree<encrypted_input_policy::merkle_hash_type, encrypted_input_policy::arity>
+        (std::cbegin(public_keys_read), std::cend(public_keys_read));
     std::vector<scalar_field_value_type> rt_field_from_read = marshaling_policy::get_multi_field_element_from_bits(tree_built_from_read.root());
     BOOST_ASSERT(rt_field == rt_field_from_read);
     std::cout << "Merkle tree generation finished." << std::endl;
@@ -1149,7 +1149,7 @@ void process_encrypted_input_mode_init_admin_phase(
     logln("Administrator pre-initializes voting session..." , "\n");
 
     logln("Merkle tree generation upon participants public keys started..." );
-    containers::merkle_tree<encrypted_input_policy::merkle_hash_type, encrypted_input_policy::arity> tree(
+    auto tree = containers::make_merkle_tree<encrypted_input_policy::merkle_hash_type, encrypted_input_policy::arity>(
         std::cbegin(public_keys), std::cend(public_keys));
     std::vector<scalar_field_value_type> rt_field = marshaling_policy::get_multi_field_element_from_bits(tree.root());
     logln("Merkle tree generation finished." );
@@ -1275,7 +1275,7 @@ void process_encrypted_input_mode_vote_phase(
     logln();
 
     logln("Voter with index " , proof_idx , " generates its merkle copath..." );
-    containers::merkle_tree<encrypted_input_policy::merkle_hash_type, encrypted_input_policy::arity> tree(
+    auto tree = containers::make_merkle_tree<encrypted_input_policy::merkle_hash_type, encrypted_input_policy::arity>(
         std::cbegin(public_keys), std::cend(public_keys));
     std::vector<scalar_field_value_type> rt_field = marshaling_policy::get_multi_field_element_from_bits(tree.root());
     BOOST_ASSERT(rt_field == admin_rt_field);

--- a/bin/cli/src/main.cpp
+++ b/bin/cli/src/main.cpp
@@ -1594,7 +1594,8 @@ void init_election(std::size_t tree_depth, std::size_t eid_bits,
                    const buffer<buffer<char> *const> *const public_keys_super_buffer,
                    buffer<char> *const r1cs_proving_key_out, buffer<char> *const r1cs_verification_key_out,
                    buffer<char> *const public_key_out, buffer<char> *const secret_key_out,
-                   buffer<char> *const verification_key_out, buffer<char> *const eid_out, buffer<char> *const rt_out) {
+                   buffer<char> *const verification_key_out, buffer<char> *const eid_out, buffer<char> *const rt_out,
+                   buffer<char> *const merkle_tree_out) {
     std::vector<std::uint8_t> r1cs_proving_key_blob;
     std::vector<std::uint8_t> r1cs_verification_key_blob;
     std::vector<std::uint8_t> public_key_blob;
@@ -1622,10 +1623,11 @@ void init_election(std::size_t tree_depth, std::size_t eid_bits,
     *verification_key_out = blob_to_buffer(verification_key_blob);
     *eid_out = blob_to_buffer(eid_blob);
     *rt_out = blob_to_buffer(rt_blob);
+    *merkle_tree_out = blob_to_buffer(merkle_tree_blob);
 }
 
 void generate_vote(std::size_t tree_depth, std::size_t eid_bits, std::size_t voter_idx, std::size_t vote,
-                   const buffer<buffer<char> *const> *const public_keys_super_buffer,
+                   const buffer<char> *const merkle_tree_buffer,
                    const buffer<char> *const rt_buffer, const buffer<char> *const eid_buffer,
                    const buffer<char> *const sk_buffer, const buffer<char> *const pk_eid_buffer,
                    const buffer<char> *const r1cs_proving_key_buffer,
@@ -1642,12 +1644,7 @@ void generate_vote(std::size_t tree_depth, std::size_t eid_bits, std::size_t vot
     std::vector<std::uint8_t> vk_crs_blob_out;
     std::vector<std::uint8_t> pk_eid_blob_out;
 
-    auto blobs = super_buffer_to_blobs(public_keys_super_buffer);
-    logln("Finished conversion from buffer to blobs of public keys" );
-
-    auto public_keys = marshaling_policy::deserialize_voters_public_keys(tree_depth, blobs);
-    logln("Finished deserialization of public keys" );
-
+    auto merkle_tree_blob = buffer_to_blob(merkle_tree_buffer);
     auto rt_blob = buffer_to_blob(rt_buffer);
     auto eid_blob = buffer_to_blob(eid_buffer);
     auto sk_blob = buffer_to_blob(sk_buffer);
@@ -1655,8 +1652,9 @@ void generate_vote(std::size_t tree_depth, std::size_t eid_bits, std::size_t vot
     auto proving_key_blob = buffer_to_blob(r1cs_proving_key_buffer);
     auto verification_key_blob = buffer_to_blob(r1cs_verification_key_buffer);
 
-    logln("Finished conversion of rt,eid,sk,pk_eid,proving_key,verification_key from buffer to blob");
+    logln("Finished conversion of merkle_tree,rt,eid,sk,pk_eid,proving_key,verification_key from buffer to blob");
 
+    auto merkle_tree = marshaling_policy::deserialize_merkle_tree(tree_depth, merkle_tree_blob);
     auto rt_field = marshaling_policy::deserialize_scalar_vector(rt_blob);
     auto eid_field = marshaling_policy::deserialize_scalar_vector(eid_blob);
     auto sk = marshaling_policy::deserialize_bitarray<encrypted_input_policy::secret_key_bits>(sk_blob);
@@ -1666,12 +1664,9 @@ void generate_vote(std::size_t tree_depth, std::size_t eid_bits, std::size_t vot
         marshaling_policy::deserialize_pk_crs(proving_key_blob),
         marshaling_policy::deserialize_vk_crs(verification_key_blob)};
 
-    logln("Finished deserialization of rt,eid,sk,pk_eid,proving_key,verification_key");
+    logln("Finished deserialization of merkle_tree,rt,eid,sk,pk_eid,proving_key,verification_key");
 
-    auto tree = containers::make_merkle_tree<encrypted_input_policy::merkle_hash_type, encrypted_input_policy::arity>(
-        std::cbegin(public_keys), std::cend(public_keys));
-
-    process_encrypted_input_mode_vote_phase(tree_depth, eid_bits, voter_idx, vote, tree, rt_field, eid_field, sk, pk_eid, gg_keypair,
+    process_encrypted_input_mode_vote_phase(tree_depth, eid_bits, voter_idx, vote, merkle_tree, rt_field, eid_field, sk, pk_eid, gg_keypair,
                                             proof_blob_out, pinput_blob_out, ct_blob_out, eid_blob_out, sn_blob_out,
                                             rt_blob_out, vk_crs_blob_out, pk_eid_blob_out);
 

--- a/share/wasm/test.js
+++ b/share/wasm/test.js
@@ -16,7 +16,7 @@ function test() {
     for(var i=0; i < num_participants; ++i) {
         vote = (i*3) % 25;
         console.log(`voter ${i} votes ${vote}`);
-        vote_data = wrapper.generate_vote(tree_depth, i, vote, public_keys,
+        vote_data = wrapper.generate_vote(tree_depth, i, vote, election.merkle_tree,
             election.rt, election.eid, keypairs[i].secret_key,
             election.public_key, election.r1cs_proving_key, election.r1cs_verification_key);
         vote_datas.push(vote_data);


### PR DESCRIPTION
generating merkle tree hashes turns out to be expensive, but since it is the same for every voter it can be computed in advance by the admin.
On my computer, in cli,  this reduced the total time for vote phase from 3 minutes to 1.
You can do the same benchmarking by running `bin/cli/cli -p test`